### PR TITLE
[WIP] New pattern syntax from egison-pattern-src

### DIFF
--- a/mini-egison.cabal
+++ b/mini-egison.cabal
@@ -38,11 +38,12 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , containers
-    , split
+    , mtl
+    , haskell-src-exts
     , haskell-src-meta
-    , regex-compat
     , template-haskell
+    , egison-pattern-src >= 0.2.0 && < 0.3
+    , egison-pattern-src-th-mode >= 0.2.0 && < 0.3
   default-language: Haskell2010
   default-extensions:
       TemplateHaskell
@@ -54,9 +55,11 @@ library
     , TypeFamilies
     , TypeOperators
     , FlexibleInstances
+    , FlexibleContexts
     , TupleSections
     , Strict
     , StrictData
+    , NamedFieldPuns
   ghc-options:  -O3
   
 test-suite mini-egison-test

--- a/sample/error.hs
+++ b/sample/error.hs
@@ -8,7 +8,7 @@ import qualified Control.Egison as M
 
 main = do
   putStrLn $ show $ matchAll [1,2,3,5] (Multiset Eql)
-                      [[mc| cons $x (cons $y (cons #(x + 1) (cons $z nil))) => (x, y, z) |]]
+                      [[mc| [$x, $y, #(x + 1), $z] -> (x, y, z) |]]
 -- [(1,3,5),(2,1,5),(1,5,3),(2,5,1)]
   putStrLn $ show $ matchAll [1,2,3,5] (Multiset Eql)
-                      [[mc| cons $x (cons $y (cons #(x + 1) (cons #(not x) nil))) => (x, y) |]]
+                      [[mc| [$x, $y, #(x + 1), #(not x)] -> (x, y) |]]

--- a/sample/poker.hs
+++ b/sample/poker.hs
@@ -19,55 +19,55 @@ card p1 p2 = Pattern (\_ _ (Card s n) -> [twoMAtoms (MAtom p1 Eql s) (MAtom p2 M
 
 poker cs =
   match cs (Multiset CardM)
-    [[mc| cons (card $s $n)
-           (cons (card #s #(n-1))
-            (cons (card #s #(n-2))
-             (cons (card #s #(n-3))
-              (cons (card #s #(n-4))
-               _)))) => "Straight flush" |],
-     [mc| cons (card _ $n)
-           (cons (card _ #n)
-            (cons (card _ #n)
-             (cons (card _ #n)
-              (cons _
-               _)))) => "Four of a kind" |],
-     [mc| cons (card _ $m)
-           (cons (card _ #m)
-            (cons (card _ #m)
-             (cons (card _ $n)
-              (cons (card _ #n)
-                _)))) => "Full house" |],
-     [mc| cons (card $s _)
-           (cons (card #s _)
-            (cons (card #s _)
-             (cons (card #s _)
-              (cons (card #s _)
-               _)))) => "Flush" |],
-     [mc| cons (card _ $n)
-           (cons (card _ #(n-1))
-            (cons (card _ #(n-2))
-             (cons (card _ #(n-3))
-              (cons (card _ #(n-4))
-               _)))) => "Straight" |],
-     [mc| cons (card _ $n)
-           (cons (card _ #n)
-            (cons (card _ #n)
-             (cons _
-              (cons _
-               _)))) => "Three of a kind" |],
-     [mc| cons (card _ $m)
-           (cons (card _ #m)
-            (cons (card _ $n)
-             (cons (card _ #n)
-              (cons _
-                _)))) => "Two pair" |],
-     [mc| cons (card _ $n)
-           (cons (card _ #n)
-            (cons _
-             (cons _
-              (cons _
-               _)))) => "One pair" |],
-     [mc| _ => "Nothing" |]]
+    [[mc| card $s $n :
+           card #s #(n-1) :
+            card #s #(n-2) :
+             card #s #(n-3) :
+              card #s #(n-4) :
+               _ -> "Straight flush" |],
+     [mc| card _ $n :
+           card _ #n :
+            card _ #n :
+             card _ #n :
+              _ :
+               _ -> "Four of a kind" |],
+     [mc| card _ $m :
+           card _ #m :
+            card _ #m :
+             card _ $n :
+              card _ #n :
+                _ -> "Full house" |],
+     [mc| card $s _ :
+           card #s _ :
+            card #s _ :
+             card #s _ :
+              card #s _ :
+               _ -> "Flush" |],
+     [mc| card _ $n :
+           card _ #(n-1) :
+            card _ #(n-2) :
+             card _ #(n-3) :
+              card _ #(n-4) :
+               _ -> "Straight" |],
+     [mc| card _ $n :
+           card _ #n :
+            card _ #n :
+             _ :
+              _ :
+               _ -> "Three of a kind" |],
+     [mc| card _ $m :
+           card _ #m :
+            card _ $n :
+             card _ #n :
+              _ :
+               _ -> "Two pair" |],
+     [mc| card _ $n :
+           card _ #n :
+            _ :
+             _ :
+              _ :
+               _ -> "One pair" |],
+     [mc| _ -> "Nothing" |]]
 
 main :: IO ()
 main = do

--- a/sample/tree.hs
+++ b/sample/tree.hs
@@ -38,5 +38,5 @@ main = do
   putStrLn $ show $ f t2 -- [0]
  where
    f t = matchAll t (TreeM Eql)
-           [[mc| nodePat $x _ _ => x |],
-            [mc| leafPat => 0 |]]
+           [[mc| nodePat $x _ _ -> x |],
+            [mc| leafPat -> 0 |]]

--- a/sample/unordered-pair.hs
+++ b/sample/unordered-pair.hs
@@ -46,5 +46,5 @@ upair p1 p2 = Pattern (\_ (UnorderedPair m') (t1, t2) ->
 main :: IO ()
 main = do
   let t1 = (1,2)
-  putStrLn $ show $ matchAll t1 UnorderedEqlPair [[mc| uepair #2 $x => x |]]
-  putStrLn $ show $ matchAll t1 (UnorderedPair Eql) [[mc| upair #2 $x => x |]]
+  putStrLn $ show $ matchAll t1 UnorderedEqlPair [[mc| uepair #2 $x -> x |]]
+  putStrLn $ show $ matchAll t1 (UnorderedPair Eql) [[mc| upair #2 $x -> x |]]

--- a/src/Control/Egison/Matcher.hs
+++ b/src/Control/Egison/Matcher.hs
@@ -93,9 +93,9 @@ instance (Matcher m a) => Matcher (List m) [a]
 instance (Matcher m a, Eq a, ValuePat m a) => ValuePat (List m) [a] where
   valuePat f = Pattern (\ctx (List m) tgt ->
                             match (f ctx, tgt) (Pair (List m) (List m)) $
-                              [[mc| ([], []) => [MNil] |],
-                               [mc| (($x : $xs), (#x : #xs)) => [MNil] |],
-                               [mc| _ => [] |]])
+                              [[mc| ([], []) -> [MNil] |],
+                               [mc| (($x : $xs), (#x : #xs)) -> [MNil] |],
+                               [mc| _ -> [] |]])
 
 instance Matcher m a => CollectionPat (List m) [a] where
   nil = Pattern (\_ _ t -> [MNil | null t])
@@ -118,16 +118,16 @@ instance (Matcher m a) => Matcher (Multiset m) [a]
 instance (Matcher m a, Eq a, ValuePat m a) => ValuePat (Multiset m) [a] where
   valuePat f = Pattern (\ctx (Multiset m) tgt ->
                             match (f ctx, tgt) (Pair (List m) (Multiset m)) $
-                              [[mc| ([], []) => [MNil] |],
-                               [mc| (($x : $xs), (#x : #xs)) => [MNil] |],
-                               [mc| _ => [] |]])
+                              [[mc| ([], []) -> [MNil] |],
+                               [mc| (($x : $xs), (#x : #xs)) -> [MNil] |],
+                               [mc| _ -> [] |]])
 
 instance (Matcher m a) => CollectionPat (Multiset m) [a] where
   nil = Pattern (\_ _ tgt -> [MNil | null tgt])
   -- | The @cons@ pattern for a multiset decomposes a collection into an arbitrary element and the rest elements.
   cons p Wildcard = Pattern (\_ (Multiset m) tgt -> map (\x -> oneMAtom (MAtom p m x)) tgt)
   cons p1 p2 = Pattern (\_ (Multiset m) tgt -> map (\(x, xs) -> twoMAtoms (MAtom p1 m x) (MAtom p2 (Multiset m) xs))
-                                                   (matchAll tgt (List m) [[mc| $hs ++ $x : $ts => (x, hs ++ ts) |]]))
+                                                   (matchAll tgt (List m) [[mc| $hs ++ $x : $ts -> (x, hs ++ ts) |]]))
   join p1 p2 = undefined
 
 -- | A matcher for a set. Both the order and the repetition of elements are ignored.
@@ -141,5 +141,5 @@ instance Matcher m a => CollectionPat (Set m) [a] where
   nil = Pattern (\_ _ tgt -> [MNil | null tgt])
   cons p1 p2 = Pattern (\_ (Set m) tgt ->
                   map (\x -> twoMAtoms (MAtom p1 m x) (MAtom p2 (Set m) tgt))
-                      (matchAll tgt (List m) [[mc| _ ++ $x : _ => x |]]))
+                      (matchAll tgt (List m) [[mc| _ ++ $x : _ -> x |]]))
   join p1 p2 = undefined

--- a/src/Control/Egison/Matcher.hs
+++ b/src/Control/Egison/Matcher.hs
@@ -93,9 +93,9 @@ instance (Matcher m a) => Matcher (List m) [a]
 instance (Matcher m a, Eq a, ValuePat m a) => ValuePat (List m) [a] where
   valuePat f = Pattern (\ctx (List m) tgt ->
                             match (f ctx, tgt) (Pair (List m) (List m)) $
-                              [[mc| pair nil nil => [MNil] |],
-                               [mc| pair (cons $x $xs) (cons #x #xs) => [MNil] |],
-                               [mc| Wildcard => [] |]])
+                              [[mc| ([], []) => [MNil] |],
+                               [mc| (($x : $xs), (#x : #xs)) => [MNil] |],
+                               [mc| _ => [] |]])
 
 instance Matcher m a => CollectionPat (List m) [a] where
   nil = Pattern (\_ _ t -> [MNil | null t])
@@ -118,16 +118,16 @@ instance (Matcher m a) => Matcher (Multiset m) [a]
 instance (Matcher m a, Eq a, ValuePat m a) => ValuePat (Multiset m) [a] where
   valuePat f = Pattern (\ctx (Multiset m) tgt ->
                             match (f ctx, tgt) (Pair (List m) (Multiset m)) $
-                              [[mc| pair nil nil => [MNil] |],
-                               [mc| pair (cons $x $xs) (cons #x #xs) => [MNil] |],
-                               [mc| Wildcard => [] |]])
+                              [[mc| ([], []) => [MNil] |],
+                               [mc| (($x : $xs), (#x : #xs)) => [MNil] |],
+                               [mc| _ => [] |]])
 
 instance (Matcher m a) => CollectionPat (Multiset m) [a] where
   nil = Pattern (\_ _ tgt -> [MNil | null tgt])
   -- | The @cons@ pattern for a multiset decomposes a collection into an arbitrary element and the rest elements.
   cons p Wildcard = Pattern (\_ (Multiset m) tgt -> map (\x -> oneMAtom (MAtom p m x)) tgt)
   cons p1 p2 = Pattern (\_ (Multiset m) tgt -> map (\(x, xs) -> twoMAtoms (MAtom p1 m x) (MAtom p2 (Multiset m) xs))
-                                                   (matchAll tgt (List m) [[mc| join $hs (cons $x $ts) => (x, hs ++ ts) |]]))
+                                                   (matchAll tgt (List m) [[mc| $hs ++ $x : $ts => (x, hs ++ ts) |]]))
   join p1 p2 = undefined
 
 -- | A matcher for a set. Both the order and the repetition of elements are ignored.
@@ -141,5 +141,5 @@ instance Matcher m a => CollectionPat (Set m) [a] where
   nil = Pattern (\_ _ tgt -> [MNil | null tgt])
   cons p1 p2 = Pattern (\_ (Set m) tgt ->
                   map (\x -> twoMAtoms (MAtom p1 m x) (MAtom p2 (Set m) tgt))
-                      (matchAll tgt (List m) [[mc| join Wildcard (cons $x Wildcard) => x |]]))
+                      (matchAll tgt (List m) [[mc| _ ++ $x : _ => x |]]))
   join p1 p2 = undefined

--- a/src/Control/Egison/QQ.hs
+++ b/src/Control/Egison/QQ.hs
@@ -1,19 +1,58 @@
 -- | Quasiquotation for rewriting a match clause.
 
-module Control.Egison.QQ (
-  mc,
-  ) where
+module Control.Egison.QQ
+  ( mc
+  )
+where
 
 import           Control.Egison.Core
-import           Data.List
-import           Data.List.Split
-import           Data.Map                   (Map)
-import           Data.Maybe                 (fromMaybe)
-import           Language.Haskell.Meta
-import           Language.Haskell.TH        hiding (match)
-import           Language.Haskell.TH.Quote
-import           Language.Haskell.TH.Syntax
-import           Text.Regex
+import           Control.Monad.State            ( runState
+                                                , get
+                                                , modify
+                                                )
+import           Text.Read                      ( readMaybe )
+import           Data.Maybe                     ( mapMaybe )
+import           Data.List                      ( foldl' )
+import           Language.Haskell.TH            ( Q
+                                                , Loc(..)
+                                                , Exp(..)
+                                                , Pat(..)
+                                                , Lit(..)
+                                                , Name
+                                                , location
+                                                , extsEnabled
+                                                , mkName
+                                                , pprint
+                                                )
+import           Language.Haskell.TH.Quote      ( QuasiQuoter(..) )
+import qualified Language.Haskell.TH           as TH
+                                                ( Extension(..) )
+import           Language.Haskell.Exts.Extension
+                                                ( Extension(EnableExtension) )
+import           Language.Haskell.Exts.Parser   ( ParseResult(..)
+                                                , defaultParseMode
+                                                , parseExpWithMode
+                                                )
+import qualified Language.Haskell.Exts.Extension
+                                               as Exts
+                                                ( KnownExtension(..) )
+import qualified Language.Haskell.Exts.Parser  as Exts
+                                                ( ParseMode(..) )
+import           Language.Haskell.Meta.Syntax.Translate
+                                                ( toExp )
+import qualified Language.Egison.Syntax.Pattern
+                                               as Pat
+                                                ( Expr(..) )
+import qualified Language.Egison.Parser.Pattern
+                                               as Pat
+                                                ( parseNonGreedy )
+import           Language.Egison.Parser.Pattern ( Fixity(..)
+                                                , ParseFixity(..)
+                                                , Associativity(..)
+                                                , Precedence(..)
+                                                )
+import           Language.Egison.Parser.Pattern.Mode.Haskell.TH
+                                                ( ParseMode(..) )
 
 -- | A quasiquoter for rewriting a match clause.
 -- This quasiquoter is useful for generating a 'MatchClause' in user-friendly syntax.
@@ -55,7 +94,7 @@ import           Text.Regex
 -- 
 -- A match clause that contains an and-pattern
 -- 
--- > [mc| (& (cons _ _) $x) => x |]
+-- > [mc| (cons _ _) & $x => x |]
 -- 
 -- is rewritten to
 -- 
@@ -66,101 +105,133 @@ import           Text.Regex
 -- 
 -- A match clause that contains an or-pattern
 -- 
--- > [mc| (| nil (cons _ _)) => "Matched" |]
+-- > [mc| nil | (cons _ _) => "Matched" |]
 -- 
 -- is rewritten to
 -- 
 -- > MatchClause (OrPat nil (cons Wildcard Wildcard))
 -- >             (\HNil -> "Matched")
+--
+-- === Collection patterns
+--
+-- A collection pattern
+--
+-- > [p1, p2, ..., pn]
+--
+-- is desugared into
+--
+-- > p1 : p2 : ... : pn : nil
+--
+-- === Cons patterns
+--
+-- A pattern with special collection pattern operator @:@
+--
+-- > p1 : p2
+--
+-- is parsed as
+--
+-- > p1 `cons` p2
+--
+-- === Join patterns
+--
+-- A pattern with special collection pattern operator @++@
+--
+-- > p1 ++ p2
+--
+-- is parsed as
+--
+-- > p1 `join` p2
 mc :: QuasiQuoter
-mc = QuasiQuoter { quoteExp = \s -> do
-                      let [pat, exp] = splitOn "=>" s
-                      e1 <- case parseExp (changeNotPat (changeOrPat (changeAndPat (changeValuePat (changePatVar (changeWildcard pat)))))) of
-                              Left _ -> fail "Could not parse pattern expression."
-                              Right exp -> return exp
-                      e2 <- case parseExp exp of
-                                 Left _ -> fail "Could not parse expression."
-                                 Right exp -> return exp
-                      mcChange e1 e2
-                  , quotePat = undefined
-                  , quoteType = undefined
-                  , quoteDec = undefined }
+mc = QuasiQuoter { quoteExp  = compile
+                 , quotePat  = undefined
+                 , quoteType = undefined
+                 , quoteDec  = undefined
+                 }
 
-changeWildcard :: String -> String
-changeWildcard pat = subRegex (mkRegex " _") pat " Wildcard"
 
-changePatVar :: String -> String
-changePatVar pat = subRegex (mkRegex "\\$([a-zA-Z0-9]+)") pat "(PatVar \"\\1\")"
+listFixities :: [ParseFixity Name String]
+listFixities =
+  [ ParseFixity (Fixity AssocRight (Precedence 5) (mkName "join")) $ parser "++"
+  , ParseFixity (Fixity AssocRight (Precedence 5) (mkName "cons")) $ parser ":"
+  ]
+ where
+  parser symbol content | symbol == content = Right ()
+                        | otherwise = Left $ show symbol ++ "is expected"
 
-changeValuePat :: String -> String
-changeValuePat pat = subRegex (mkRegex "\\#(\\([^)]+\\)|\\[[^)]+\\]|[a-zA-Z0-9]+)") pat "(valuePat \\1)"
+parseMode :: Q Exts.ParseMode
+parseMode = do
+  Loc { loc_filename } <- location
+  extensions <- mapMaybe (fmap EnableExtension . convertExt) <$> extsEnabled
+  pure defaultParseMode { Exts.parseFilename = loc_filename, Exts.extensions }
+ where
+  convertExt :: TH.Extension -> Maybe Exts.KnownExtension
+  convertExt TH.TemplateHaskellQuotes = Just Exts.TemplateHaskell  -- haskell-suite/haskell-src-exts#357
+  convertExt ext                      = readMaybe $ show ext
 
-changeAndPat :: String -> String
-changeAndPat pat = subRegex (mkRegex "\\(\\&") pat "(AndPat"
+parseExp :: Exts.ParseMode -> String -> Q Exp
+parseExp mode content = case parseExpWithMode mode content of
+  ParseOk x       -> pure $ toExp x
+  ParseFailed _ e -> fail e
 
-changeOrPat :: String -> String
-changeOrPat pat = subRegex (mkRegex "\\(\\|") pat "(OrPat"
+compile :: String -> Q Exp
+compile content = do
+  mode        <- parseMode
+  (pat, rest) <- parsePatternExpr mode content
+  bodySource  <- takeBody rest
+  body        <- parseExp mode bodySource
+  pure $ compilePattern pat body
+ where
+  takeBody ('=' : '>' : xs) = pure xs
+  takeBody xs               = fail $ "\"=>\" is expected, but found " ++ show xs
 
-changeNotPat :: String -> String
-changeNotPat pat = subRegex (mkRegex "\\(not ") pat "(NotPat "
+parsePatternExpr
+  :: Exts.ParseMode -> String -> Q (Pat.Expr Name Name Exp, String)
+parsePatternExpr haskellMode content = case Pat.parseNonGreedy mode content of
+  Left  e -> fail $ show e
+  Right x -> pure x
+  where mode = ParseMode { haskellMode, fixities = Just listFixities }
 
-mcChange :: Exp -> Exp -> Q Exp
-mcChange pat expr = do
-  let (vars, xs) = extractPatVars [pat] []
-  [| (MatchClause $(fst <$> changePat pat (map (`take` vars) xs)) $(changeExp vars expr)) |]
-
--- extract patvars from pattern
-extractPatVars :: [Exp] -> [String] -> ([String], [Int])
-extractPatVars [] vars = (vars, [])
-extractPatVars (ParensE x:xs) vars = extractPatVars (x:xs) vars
-extractPatVars (AppE (ConE name) p:xs) vars
-  | nameBase name == "PatVar" = case p of (LitE (StringL s)) -> extractPatVars xs (vars ++ [s])
-  | nameBase name == "PredicatePat" = let (vs, ns) = extractPatVars xs vars in (vs, length vars:ns)
-  | nameBase name == "LaterPat" =
-      let (vs1, ns1) = extractPatVars xs vars in
-      let (vs2, ns2) = extractPatVars [p] vs1 in (vs2, ns2 ++ ns1)
-  | otherwise = extractPatVars (p:xs) vars
-extractPatVars (AppE (VarE name) p:xs) vars
-  | nameBase name == "valuePat" = let (vs, ns) = extractPatVars xs vars in (vs, length vars:ns)
-  | otherwise = extractPatVars (p:xs) vars
-extractPatVars (AppE a b:xs) vars = extractPatVars (a:b:xs) vars
-extractPatVars (SigE x typ:xs) vs = extractPatVars (x:xs) vs
-extractPatVars (_:xs) vars = extractPatVars xs vars
-
--- change ValuePat e to \(HCons x HNil) -> e
--- change PredicatePat (\x -> e) to \(HCons x HNil) -> (\x -> e)
-changePat :: Exp -> [[String]] -> Q (Exp, [[String]])
-changePat e@(AppE (ConE name) p) vs
-  | nameBase name == "PredicatePat" = do
-      let (vars:varss) = vs
-      (, varss) <$> appE (conE 'PredicatePat) (changeExp vars p)
-  | otherwise = do
-      (e', vs') <- changePat p vs
-      (, vs') <$> appE (conE name) (return e')
-changePat e@(AppE (VarE name) p) vs
-  | nameBase name == "valuePat" = do
-      let (vars:varss) = vs
-      (, varss) <$> appE (varE name) (changeExp vars p)
-  | otherwise = do
-      (e', vs') <- changePat p vs
-      (, vs') <$> appE (varE name) (return e')
-changePat (AppE e1 e2) vs = do
-  (e1', vs') <- changePat e1 vs
-  (e2', vs'') <- changePat e2 vs'
-  (, vs'') <$> appE (return e1') (return e2')
-changePat (ParensE x) vs = changePat x vs
-changePat (SigE x typ) vs = changePat x vs
-changePat e vs = return (e, vs)
-
--- change e to \(HCons x HNil) -> e
-changeExp :: [String] -> Exp -> Q Exp
-changeExp vars expr = do
-  vars' <- mapM newName vars
-  vars'' <- mapM (\s -> newName $ s ++ "'") vars
-  return $ LamE [f vars'] expr
-
--- \[x, y] -> HCons x (HCons y HNil)
-f :: [Name] -> Pat
-f = foldr go $ ConP 'HNil []
-  where
-    go x acc = ConP 'HCons [VarP x, acc]
+compilePattern :: Pat.Expr Name Name Exp -> Exp -> Exp
+compilePattern pat body = AppE
+  (AppE (ConE 'Control.Egison.Core.MatchClause) clauseExp)
+  bodyExp
+ where
+  (clauseExp, bsAll) = runState (go pat) []
+  bodyExp            = bsFun bsAll body
+  bsFun bs = LamE [foldr (\x a -> ConP 'HCons [VarP x, a]) (ConP 'HNil []) bs]
+  go Pat.Wildcard     = pure $ ConE 'Control.Egison.Core.Wildcard
+  go (Pat.Variable v) = do
+    modify (<> [v])
+    pure . AppE (ConE 'Control.Egison.Core.PatVar) . LitE . StringL $ pprint v
+  go (Pat.Value e) = do
+    bs <- get
+    pure . AppE (VarE $ mkName "valuePat") $ bsFun bs e
+  go (Pat.Predicate e) = do
+    bs <- get
+    pure . AppE (ConE 'Control.Egison.Core.PredicatePat) $ bsFun bs e
+  go (Pat.And p1 p2) = do
+    e1 <- go p1
+    e2 <- go p2
+    pure $ AppE (AppE (ConE 'Control.Egison.Core.AndPat) e1) e2
+  go (Pat.Or p1 p2) = do
+    e1 <- go p1
+    e2 <- go p2
+    pure $ AppE (AppE (ConE 'Control.Egison.Core.OrPat) e1) e2
+  go (Pat.Not p1) = do
+    e1 <- go p1
+    pure $ AppE (ConE 'Control.Egison.Core.NotPat) e1
+  go (Pat.Tuple [p1, p2]) = do
+    e1 <- go p1
+    e2 <- go p2
+    pure $ AppE (AppE (VarE $ mkName "pair") e1) e2
+  go (Pat.Tuple _) = error "tuples other than pairs are not supported"
+  go (Pat.Collection ps) =
+    foldr (\e -> AppE (AppE (VarE $ mkName "cons") e)) (VarE $ mkName "nil")
+      <$> mapM go ps
+  go (Pat.Infix n p1 p2) = do
+    e1 <- go p1
+    e2 <- go p2
+    pure . ParensE $ UInfixE e1 (VarE n) e2
+  go (Pat.Pattern n ps) = do
+    es <- mapM go ps
+    pure $ foldl' AppE (VarE n) es

--- a/src/Control/Egison/QQ.hs
+++ b/src/Control/Egison/QQ.hs
@@ -181,8 +181,8 @@ compile content = do
   body        <- parseExp mode bodySource
   pure $ compilePattern pat body
  where
-  takeBody ('=' : '>' : xs) = pure xs
-  takeBody xs               = fail $ "\"=>\" is expected, but found " ++ show xs
+  takeBody ('-' : '>' : xs) = pure xs
+  takeBody xs               = fail $ "\"->\" is expected, but found " ++ show xs
 
 parsePatternExpr
   :: Exts.ParseMode -> String -> Q (Pat.Expr Name Name Exp, String)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,38 +10,38 @@ import           Test.Hspec
 
 pmap :: (a -> b) -> [a] -> [b]
 pmap f xs = matchAll xs (List Something)
-             [[mc| join _ (cons $x _) => f x |]]
+             [[mc| _ ++ $x : _ => f x |]]
 
 pmConcat :: [[a]] -> [a]
 pmConcat xss = matchAll xss (Multiset (Multiset Something))
-                 [[mc| cons (cons $x _) _ => x |]]
+                 [[mc| ($x : _) : _ => x |]]
 
 pmUniq :: (Eq a) => [a] -> [a]
 pmUniq xs = matchAll xs (List Eql)
-               [[mc| join _ (cons $x (not (join _ (cons #x _)))) => x |]]
+               [[mc| _ ++ $x : !(_ ++ #x : _) => x |]]
 
 pmIntersect :: (Eq a) => [a] -> [a] -> [a]
 pmIntersect xs ys = matchAll (xs, ys) (Pair (Multiset Eql) (Multiset Eql))
-                      [[mc| pair (cons $x _) (cons #x _) => x |]]
+                      [[mc| (($x : _), (#x : _)) => x |]]
 
 pmDiff :: (Eq a) => [a] -> [a] -> [a]
 pmDiff xs ys = matchAll (xs, ys) (Pair (Multiset Eql) (Multiset Eql))
-                 [[mc| pair (cons $x _) (not (cons #x _)) => x |]]
+                 [[mc| (($x : _), !(#x : _)) => x |]]
 
 spec :: Spec
 spec = do
   describe "list and multiset matchers" $ do
     it "cons pattern for list" $
-      matchAll [1,2,3] (List Integer) [[mc| cons $x $xs => (x, xs) |]]
+      matchAll [1,2,3] (List Integer) [[mc| $x : $xs => (x, xs) |]]
       `shouldBe` [(1, [2,3])]
 
     it "multiset cons pattern" $
-      matchAll [1,2,3] (Multiset Integer) [[mc| cons $x $xs => (x, xs) |]]
+      matchAll [1,2,3] (Multiset Integer) [[mc| $x : $xs => (x, xs) |]]
       `shouldBe` [(1,[2,3]),(2,[1,3]),(3,[1,2])]
 
     it "join pattern for list matcher" $ length (
       matchAll [1..5] (List Integer)
-        [[mc| join $xs $ys => (xs, ys) |]])
+        [[mc| $xs ++ $ys => (xs, ys) |]])
       `shouldBe` 6
 
     it "value pattern for list matcher (1)" $
@@ -70,39 +70,39 @@ spec = do
   describe "match-all with infinitely many results" $ do
     it "Check the order of pattern-matching results (multiset bfs) " $
       take 10 (matchAll [1..] (Multiset Integer)
-                 [[mc| cons $x (cons $y _) => (x, y) |]])
+                 [[mc| $x : $y : _ => (x, y) |]])
       `shouldBe` [(1,2),(1,3),(2,1),(1,4),(2,3),(3,1),(1,5),(2,4),(3,2),(4,1)]
 
     it "Check the order of pattern-matching results (set bfs)" $
       take 10 (matchAll [1..] (Set Integer)
-                 [[mc| cons $x (cons $y _) => (x, y) |]])
+                 [[mc| $x : $y : _ => (x, y) |]])
       `shouldBe` [(1,1),(1,2),(2,1),(1,3),(2,2),(3,1),(1,4),(2,3),(3,2),(4,1)]
 
     it "Check the order of pattern-matching results (set dfs)" $
       take 10 (matchAllDFS [1..] (Set Integer)
-                 [[mc| cons $x (cons $y _) => (x, y) |]])
+                 [[mc| $x : $y : _ => (x, y) |]])
       `shouldBe` [(1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,10)]
 
   describe "built-in pattern constructs" $ do
     it "Predicate patterns" $
       matchAll [1..10] (Multiset Integer)
-        [[mc| cons (& (PredicatePat (\x -> mod x 2 == 0)) $x) _ => x |]]
+        [[mc| (?(\x -> mod x 2 == 0) & $x) : _ => x |]]
       `shouldBe` [2,4,6,8,10]
 
   describe "patterns for prime numbers" $ do
     it "twin primes (p, p+2)" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| join _ (cons $p (cons #(p+2) _)) => (p, p+2) |]])
+                 [[mc| _ ++ $p : #(p+2) : _ => (p, p+2) |]])
       `shouldBe` [(3,5),(5,7),(11,13),(17,19),(29,31),(41,43),(59,61),(71,73),(101,103),(107,109)]
 
     it "prime pairs whose form is (p, p+6) -- pattern matching with infinitely many results" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| join _ (cons $p (join _ (cons #(p+6) _))) => (p, p+6) |]])
+                 [[mc| _ ++ $p : _ ++ #(p+6) : _ => (p, p+6) |]])
       `shouldBe` [(5,11),(7,13),(11,17),(13,19),(17,23),(23,29),(31,37),(37,43),(41,47),(47,53)]
 
     it "prime triplets -- and-patterns, or-patterns, and not-patterns" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| join _ (cons $p (cons (& (| #(p+2) #(p+4)) $m) (cons #(p+6) _))) => (p, m, p+6) |]])
+                 [[mc| _ ++ $p : ($m & (#(p+2) | #(p+4))) : #(p+6) : _ => (p, m, p+6) |]])
       `shouldBe` [(5,7,11),(7,11,13),(11,13,17),(13,17,19),(17,19,23),(37,41,43),(41,43,47),(67,71,73),(97,101,103),(101,103,107)]
 
   describe "Basic list processing functions" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,99 +10,99 @@ import           Test.Hspec
 
 pmap :: (a -> b) -> [a] -> [b]
 pmap f xs = matchAll xs (List Something)
-             [[mc| _ ++ $x : _ => f x |]]
+             [[mc| _ ++ $x : _ -> f x |]]
 
 pmConcat :: [[a]] -> [a]
 pmConcat xss = matchAll xss (Multiset (Multiset Something))
-                 [[mc| ($x : _) : _ => x |]]
+                 [[mc| ($x : _) : _ -> x |]]
 
 pmUniq :: (Eq a) => [a] -> [a]
 pmUniq xs = matchAll xs (List Eql)
-               [[mc| _ ++ $x : !(_ ++ #x : _) => x |]]
+               [[mc| _ ++ $x : !(_ ++ #x : _) -> x |]]
 
 pmIntersect :: (Eq a) => [a] -> [a] -> [a]
 pmIntersect xs ys = matchAll (xs, ys) (Pair (Multiset Eql) (Multiset Eql))
-                      [[mc| (($x : _), (#x : _)) => x |]]
+                      [[mc| (($x : _), (#x : _)) -> x |]]
 
 pmDiff :: (Eq a) => [a] -> [a] -> [a]
 pmDiff xs ys = matchAll (xs, ys) (Pair (Multiset Eql) (Multiset Eql))
-                 [[mc| (($x : _), !(#x : _)) => x |]]
+                 [[mc| (($x : _), !(#x : _)) -> x |]]
 
 spec :: Spec
 spec = do
   describe "list and multiset matchers" $ do
     it "cons pattern for list" $
-      matchAll [1,2,3] (List Integer) [[mc| $x : $xs => (x, xs) |]]
+      matchAll [1,2,3] (List Integer) [[mc| $x : $xs -> (x, xs) |]]
       `shouldBe` [(1, [2,3])]
 
     it "multiset cons pattern" $
-      matchAll [1,2,3] (Multiset Integer) [[mc| $x : $xs => (x, xs) |]]
+      matchAll [1,2,3] (Multiset Integer) [[mc| $x : $xs -> (x, xs) |]]
       `shouldBe` [(1,[2,3]),(2,[1,3]),(3,[1,2])]
 
     it "join pattern for list matcher" $ length (
       matchAll [1..5] (List Integer)
-        [[mc| $xs ++ $ys => (xs, ys) |]])
+        [[mc| $xs ++ $ys -> (xs, ys) |]])
       `shouldBe` 6
 
     it "value pattern for list matcher (1)" $
       match [1,2,3] (List Integer)
-        [[mc| #[1,2,3] => "Matched" |],
-         [mc| _ => "Not matched" |]]
+        [[mc| #[1,2,3] -> "Matched" |],
+         [mc| _ -> "Not matched" |]]
       `shouldBe` "Matched"
 
     it "value pattern for list matcher (2)" $
       match [1,2,3] (List Integer)
-        [[mc| #[2,1,3] => "Matched" |],
-         [mc| _ => "Not matched" |]]
+        [[mc| #[2,1,3] -> "Matched" |],
+         [mc| _ -> "Not matched" |]]
       `shouldBe` "Not matched"
 
     it "value pattern for multiset matcher" $
       match [1,2,3] (Multiset Integer)
-        [[mc| #[2,1,3] => "Matched" |],
-         [mc| _ => "Not matched" |]]
+        [[mc| #[2,1,3] -> "Matched" |],
+         [mc| _ -> "Not matched" |]]
       `shouldBe` "Matched"
 
 --    it "test" $
 --      match 1 (List Integer)
---        [[mc| $x => "Matched" |]]
+--        [[mc| $x -> "Matched" |]]
 --      `shouldBe` "Matched"
 
   describe "match-all with infinitely many results" $ do
     it "Check the order of pattern-matching results (multiset bfs) " $
       take 10 (matchAll [1..] (Multiset Integer)
-                 [[mc| $x : $y : _ => (x, y) |]])
+                 [[mc| $x : $y : _ -> (x, y) |]])
       `shouldBe` [(1,2),(1,3),(2,1),(1,4),(2,3),(3,1),(1,5),(2,4),(3,2),(4,1)]
 
     it "Check the order of pattern-matching results (set bfs)" $
       take 10 (matchAll [1..] (Set Integer)
-                 [[mc| $x : $y : _ => (x, y) |]])
+                 [[mc| $x : $y : _ -> (x, y) |]])
       `shouldBe` [(1,1),(1,2),(2,1),(1,3),(2,2),(3,1),(1,4),(2,3),(3,2),(4,1)]
 
     it "Check the order of pattern-matching results (set dfs)" $
       take 10 (matchAllDFS [1..] (Set Integer)
-                 [[mc| $x : $y : _ => (x, y) |]])
+                 [[mc| $x : $y : _ -> (x, y) |]])
       `shouldBe` [(1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,10)]
 
   describe "built-in pattern constructs" $ do
     it "Predicate patterns" $
       matchAll [1..10] (Multiset Integer)
-        [[mc| (?(\x -> mod x 2 == 0) & $x) : _ => x |]]
+        [[mc| (?(\x -> mod x 2 == 0) & $x) : _ -> x |]]
       `shouldBe` [2,4,6,8,10]
 
   describe "patterns for prime numbers" $ do
     it "twin primes (p, p+2)" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| _ ++ $p : #(p+2) : _ => (p, p+2) |]])
+                 [[mc| _ ++ $p : #(p+2) : _ -> (p, p+2) |]])
       `shouldBe` [(3,5),(5,7),(11,13),(17,19),(29,31),(41,43),(59,61),(71,73),(101,103),(107,109)]
 
     it "prime pairs whose form is (p, p+6) -- pattern matching with infinitely many results" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| _ ++ $p : _ ++ #(p+6) : _ => (p, p+6) |]])
+                 [[mc| _ ++ $p : _ ++ #(p+6) : _ -> (p, p+6) |]])
       `shouldBe` [(5,11),(7,13),(11,17),(13,19),(17,23),(23,29),(31,37),(37,43),(41,47),(47,53)]
 
     it "prime triplets -- and-patterns, or-patterns, and not-patterns" $
       take 10 (matchAll primes (List Integer)
-                 [[mc| _ ++ $p : ($m & (#(p+2) | #(p+4))) : #(p+6) : _ => (p, m, p+6) |]])
+                 [[mc| _ ++ $p : ($m & (#(p+2) | #(p+4))) : #(p+6) : _ -> (p, m, p+6) |]])
       `shouldBe` [(5,7,11),(7,11,13),(11,13,17),(13,17,19),(17,19,23),(37,41,43),(41,43,47),(67,71,73),(97,101,103),(101,103,107)]
 
   describe "Basic list processing functions" $ do


### PR DESCRIPTION
- use new pattern syntax from `egison-pattern-src` (implemented via `egison-pattern-src-th-mode`)
- a delimiter of match clauses is now `->`, not `=>`
- `[p1, p2, ..., pn]` is desugared to `p1 : p2 : ... : pn : nil`
  * `[]` is `nil`
- `:` is desugared to `cons`
- `++` is desugared to `join`
- `(p1, p2)` is desugared to `pair p1 p2`

WIP:
- I found a bug in `egison-pattern-src` that causes a compilation error here
- Improve implementation of `compilePattern`
  * `cataM` ?
  * stop using `error`