### PR TITLE
Write benchmarks using criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,43 +250,26 @@ poker cs =
 
 ## Benchmark
 
-We benchmarked this library using the program that enumerates the first 100 twin primes.
-This Haskell library is faster (more than 20 times in this case) than the original Egison interpreter!
+We benchmarked this library using the program that enumerates the first 50 (p, p+6) primes.
+This Haskell library is much faster than the original Egison interpreter!
 
-```hs
-$ cat benchmark/prime-pairs-2.hs
-{-# LANGUAGE QuasiQuotes     #-}
-{-# LANGUAGE GADTs           #-}
-
-import Control.Egison
-import Data.Numbers.Primes
-
-main :: IO ()
-main = do
-  let n = 100
-  let ans = take n (matchAll primes (List Integer)
-                     [[mc| _ ++ $p : #(p+2) : _ -> (p, p+2) |]])
-  putStrLn $ show ans
-$ stack ghc -- benchmark/prime-pairs-2.hs
-$ time ./benchmark/prime-pairs-2
-[(3,5),(5,7),(11,13), ..., (3671,3673),(3767,3769),(3821,3823)]
-./benchmark/prime-pairs-2  0.01s user 0.01s system 64% cpu 0.024 total
 ```
+$ cabal new-bench prime-pairs
+...
+benchmarking (p, p+6) pairs/50/egison
+time                 5.066 s    (4.610 s .. 5.608 s)
+                     0.999 R²   (0.995 R² .. 1.000 R²)
+mean                 4.932 s    (4.807 s .. 5.017 s)
+std dev              120.2 ms   (34.72 ms .. 161.7 ms)
+variance introduced by outliers: 19% (moderately inflated)
 
-```hs
-$ cat benchmark/prime-pairs-2.egi
-(define $n 100)
-(define $primes {2 3 5 7 11 13 17 ... 4391 4397 4409})
-
-(define $twin-primes
-  (match-all primes (list integer)
-    [<join _ <cons $p <cons ,(+ p 2) _>>>
-     [p (+ p 2)]]))
-
-(take n twin-primes)
-$ time stack exec egison -- -t benchmark/prime-pairs-2.egi
-{[3 5] [5 7] [11 13] ... [3671 3673] [3767 3769] [3821 3823]}
-stack exec egison -- -t benchmark/prime-pairs-2.egi  0.54s user 0.04s system 97% cpu 0.593 total
+benchmarking (p, p+6) pairs/50/miniEgison
+time                 2.415 ms   (2.264 ms .. 2.527 ms)
+                     0.984 R²   (0.975 R² .. 0.991 R²)
+mean                 2.196 ms   (2.106 ms .. 2.266 ms)
+std dev              252.3 μs   (219.0 μs .. 296.6 μs)
+variance introduced by outliers: 73% (severely inflated)
+...
 ```
 
 ## Sponsors

--- a/benchmark/comb2.hs
+++ b/benchmark/comb2.hs
@@ -1,0 +1,35 @@
+import           Control.Egison
+
+import           Data.List                      ( tails )
+import           Criterion.Main
+
+
+comb2 :: Int -> [(Int, Int)]
+comb2 n = matchAllDFS [1 .. n]
+                      (List Something)
+                      [[mc| _ ++ $x : _ ++ $y : _ -> (x, y) |]]
+
+comb2Native :: Int -> [(Int, Int)]
+comb2Native n = [ (y, z) | y : ts <- tails xs, z <- ts ] where xs = [1 .. n]
+
+main :: IO ()
+main = defaultMain
+  [ bgroup
+      "comb2"
+      [ bgroup
+        "1600"
+        [ bench "native" $ nf comb2Native 1600
+        , bench "miniEgison" $ nf comb2 1600
+        ]
+      , bgroup
+        "3200"
+        [ bench "native" $ nf comb2Native 3200
+        , bench "miniEgison" $ nf comb2 3200
+        ]
+      , bgroup
+        "6400"
+        [ bench "native" $ nf comb2Native 6400
+        , bench "miniEgison" $ nf comb2 6400
+        ]
+      ]
+  ]

--- a/benchmark/perm2.hs
+++ b/benchmark/perm2.hs
@@ -1,0 +1,37 @@
+import           Control.Egison
+
+import           Criterion.Main
+
+
+perm2 :: Int -> [(Int, Int)]
+perm2 n =
+  matchAllDFS [1 .. n] (Multiset Something) [[mc| $x : $y : _ -> (x, y) |]]
+
+perm2Native :: Int -> [(Int, Int)]
+perm2Native n = go [1 .. n] [] []
+ where
+  go [] _ acc = acc
+  go (x : xs) rest acc =
+    [ (x, y) | y <- rest ++ xs ] ++ go xs (rest ++ [x]) acc
+
+main :: IO ()
+main = defaultMain
+  [ bgroup
+      "perm2"
+      [ bgroup
+        "1600"
+        [ bench "native" $ nf perm2Native 1600
+        , bench "miniEgison" $ nf perm2 1600
+        ]
+      , bgroup
+        "3200"
+        [ bench "native" $ nf perm2Native 3200
+        , bench "miniEgison" $ nf perm2 3200
+        ]
+      , bgroup
+        "6400"
+        [ bench "native" $ nf perm2Native 6400
+        , bench "miniEgison" $ nf perm2 6400
+        ]
+      ]
+  ]

--- a/benchmark/primePairs.hs
+++ b/benchmark/primePairs.hs
@@ -3,12 +3,34 @@
 import           Control.Egison
 
 import           Data.Numbers.Primes            ( primes )
+import           Language.Egison                ( initialEnv
+                                                , runEgisonExpr
+                                                , EgisonValue
+                                                )
+import           Language.Egison.CmdOptions     ( defaultOption
+                                                , EgisonOpts(..)
+                                                )
 import           Criterion.Main
 
+
+runWithEgison :: String -> IO EgisonValue
+runWithEgison expr = do
+  egisonEnv   <- initialEnv option
+  Right value <- runEgisonExpr option egisonEnv expr
+  pure value
+  where option = defaultOption { optSExpr = False }
 
 primePairs2 :: Int -> [(Int, Int)]
 primePairs2 n = take n
   $ matchAll primes (List Integer) [[mc| _ ++ $p : #(p+2) : _ -> (p, p+2) |]]
+
+primePairs2Egison :: Int -> IO EgisonValue
+primePairs2Egison n = runWithEgison expr
+ where
+  expr =
+    "take "
+      ++ show n
+      ++ " (matchAll primes as list integer with _ ++ $p :: #(p+2) :: _ -> (p, p+2))"
 
 primePairs6 :: Int -> [(Int, Int)]
 primePairs6 n = take n $ matchAll
@@ -16,17 +38,35 @@ primePairs6 n = take n $ matchAll
   (List Integer)
   [[mc| _ ++ $p : _ ++ #(p+6) : _ -> (p, p+6) |]]
 
+primePairs6Egison :: Int -> IO EgisonValue
+primePairs6Egison n = runWithEgison expr
+ where
+  expr =
+    "take "
+      ++ show n
+      ++ " (matchAll primes as list integer with _ ++ $p :: _ ++ #(p+6) :: _ -> (p, p+6))"
+
 main :: IO ()
 main = defaultMain
   [ bgroup
     "(p, p+2) pairs"
-    [ bench "12800" $ nf primePairs2 12800
+    [ bgroup
+      "50"
+      [ bench "egison" $ whnfAppIO primePairs2Egison 50
+      , bench "miniEgison" $ nf primePairs2 50
+      ]
+    , bench "12800" $ nf primePairs2 12800
     , bench "25600" $ nf primePairs2 25600
     , bench "51200" $ nf primePairs2 51200
     ]
   , bgroup
     "(p, p+6) pairs"
-    [ bench "128" $ nf primePairs6 128
+    [ bgroup
+      "50"
+      [ bench "egison" $ whnfAppIO primePairs6Egison 50
+      , bench "miniEgison" $ nf primePairs6 50
+      ]
+    , bench "128" $ nf primePairs6 128
     , bench "256" $ nf primePairs6 256
     , bench "512" $ nf primePairs6 512
     ]

--- a/benchmark/primePairs.hs
+++ b/benchmark/primePairs.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS_GHC -fno-full-laziness #-}
+
+import           Control.Egison
+
+import           Data.Numbers.Primes            ( primes )
+import           Criterion.Main
+
+
+primePairs2 :: Int -> [(Int, Int)]
+primePairs2 n = take n
+  $ matchAll primes (List Integer) [[mc| _ ++ $p : #(p+2) : _ -> (p, p+2) |]]
+
+primePairs6 :: Int -> [(Int, Int)]
+primePairs6 n = take n $ matchAll
+  primes
+  (List Integer)
+  [[mc| _ ++ $p : _ ++ #(p+6) : _ -> (p, p+6) |]]
+
+main :: IO ()
+main = defaultMain
+  [ bgroup
+    "(p, p+2) pairs"
+    [ bench "12800" $ nf primePairs2 12800
+    , bench "25600" $ nf primePairs2 25600
+    , bench "51200" $ nf primePairs2 51200
+    ]
+  , bgroup
+    "(p, p+6) pairs"
+    [ bench "128" $ nf primePairs6 128
+    , bench "256" $ nf primePairs6 256
+    , bench "512" $ nf primePairs6 512
+    ]
+  ]

--- a/mini-egison.cabal
+++ b/mini-egison.cabal
@@ -91,3 +91,33 @@ Executable cdcl
   Hs-Source-Dirs:      sample
   default-language: Haskell2010
   ghc-options:  -O3
+
+benchmark comb2
+  type: exitcode-stdio-1.0
+  main-is: comb2.hs
+  hs-source-dirs: benchmark
+  ghc-options: -O3 -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions:
+      TemplateHaskell
+    , QuasiQuotes
+    , GADTs
+  build-depends:
+      base
+    , mini-egison
+    , criterion >= 1
+
+benchmark perm2
+  type: exitcode-stdio-1.0
+  main-is: perm2.hs
+  hs-source-dirs: benchmark
+  ghc-options: -O3 -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions:
+      TemplateHaskell
+    , QuasiQuotes
+    , GADTs
+  build-depends:
+      base
+    , mini-egison
+    , criterion >= 1

--- a/mini-egison.cabal
+++ b/mini-egison.cabal
@@ -121,3 +121,19 @@ benchmark perm2
       base
     , mini-egison
     , criterion >= 1
+
+benchmark prime-pairs
+  type: exitcode-stdio-1.0
+  main-is: primePairs.hs
+  hs-source-dirs: benchmark
+  ghc-options: -O3 -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+  default-extensions:
+      TemplateHaskell
+    , QuasiQuotes
+    , GADTs
+  build-depends:
+      base
+    , mini-egison
+    , criterion >= 1
+    , primes

--- a/mini-egison.cabal
+++ b/mini-egison.cabal
@@ -137,3 +137,4 @@ benchmark prime-pairs
     , mini-egison
     , criterion >= 1
     , primes
+    , egison >= 3.10.0 && < 3.11


### PR DESCRIPTION
This PR enables to execute benchmark programs in a uniform and reliable way.

- `cabal new-bench --jobs=1` runs benchmarks sequentially.
  * `stack bench` is also available.
- `cabal new-run <benchmark name> -- --output output.html` produces detailed report to `output.html`
- All benchmarks under `benchmark/` directory are re-implemented in this way.

## TODO

- [x] Rewrite README